### PR TITLE
add close argument to DeleteConnection

### DIFF
--- a/programs/gpl_core/src/instructions/connection.rs
+++ b/programs/gpl_core/src/instructions/connection.rs
@@ -93,6 +93,7 @@ pub struct DeleteConnection<'info> {
         bump,
         has_one = from_profile,
         has_one = to_profile,
+        close = authority,
     )]
     pub connection: Account<'info, Connection>,
     #[account(


### PR DESCRIPTION
I tried to delete a connection account in this [tx](https://explorer.solana.com/tx/49pC4iMwBPbHwc9qRDwZkSa9ViPPjL1fg7xUiJzE1eBYG2kXDBy7btJVXCgZB9Md82gyNGUA2Qgyh3YY3o2HCgjt?cluster=devnet) and the account is still there.
Found out the program ix didn't add close argument to `connection` account in `DeleteConnection` 