### PR TITLE
Add separate payer field to pay initialization fee when creating accounts

### DIFF
--- a/programs/gpl_core/src/instructions/connection.rs
+++ b/programs/gpl_core/src/instructions/connection.rs
@@ -11,6 +11,8 @@ use crate::events::{ConnectionDeleted, ConnectionNew};
 // Create a connection between two profiles, ie from_profile -> to_profile
 #[derive(Accounts, Session)]
 pub struct CreateConnection<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
     // The account that will be initialized as a Connection
     #[account(
         init,
@@ -20,7 +22,7 @@ pub struct CreateConnection<'info> {
             to_profile.key().as_ref()
         ],
         bump,
-        payer = authority,
+        payer = payer,
         space = Connection::LEN
     )]
     pub connection: Account<'info, Connection>,
@@ -58,7 +60,6 @@ pub struct CreateConnection<'info> {
     )]
     pub session_token: Option<Account<'info, SessionToken>>,
 
-    #[account(mut)]
     pub authority: Signer<'info>,
     // The system program
     pub system_program: Program<'info, System>,

--- a/programs/gpl_core/src/instructions/post.rs
+++ b/programs/gpl_core/src/instructions/post.rs
@@ -14,6 +14,8 @@ use gpl_session::{SessionError, SessionToken};
 #[derive(Accounts, Session)]
 #[instruction(metadata_uri: String, random_hash: [u8;32])]
 pub struct CreatePost<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
     // The account that will be initialized as a Post
     #[account(
         init,
@@ -22,7 +24,7 @@ pub struct CreatePost<'info> {
             random_hash.as_ref(),
         ],
         bump,
-        payer = authority,
+        payer = payer,
         space = Post::LEN
     )]
     pub post: Account<'info, Post>,
@@ -50,8 +52,7 @@ pub struct CreatePost<'info> {
         authority = user.authority.key()
     )]
     pub session_token: Option<Account<'info, SessionToken>>,
-
-    #[account(mut)]
+    
     pub authority: Signer<'info>,
     // The system program
     pub system_program: Program<'info, System>,
@@ -154,6 +155,8 @@ pub fn update_post_handler(ctx: Context<UpdatePost>, metadata_uri: String) -> Re
 #[derive(Accounts, Session)]
 #[instruction(metadata_uri: String, random_hash: [u8;32])]
 pub struct CreateComment<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
     // The account that will be initialized as a Post
     #[account(
         init,
@@ -162,7 +165,7 @@ pub struct CreateComment<'info> {
             random_hash.as_ref(),
         ],
         bump,
-        payer = authority,
+        payer = payer,
         space = Post::LEN
     )]
     pub post: Account<'info, Post>,
@@ -197,7 +200,6 @@ pub struct CreateComment<'info> {
         authority = user.authority.key()
     )]
     pub session_token: Option<Account<'info, SessionToken>>,
-    #[account(mut)]
     pub authority: Signer<'info>,
     // The system program
     pub system_program: Program<'info, System>,

--- a/programs/gpl_core/src/instructions/profile.rs
+++ b/programs/gpl_core/src/instructions/profile.rs
@@ -10,6 +10,8 @@ use crate::events::{ProfileDeleted, ProfileNew};
 #[derive(Accounts)]
 #[instruction(namespace: String)]
 pub struct CreateProfile<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
     // The account that will be initialized as a Profile
     #[account(
         init,
@@ -19,7 +21,7 @@ pub struct CreateProfile<'info> {
             user.to_account_info().key.as_ref()
         ],
         bump,
-        payer = authority,
+        payer = payer,
         space = Profile::LEN
     )]
     pub profile: Account<'info, Profile>,
@@ -32,7 +34,6 @@ pub struct CreateProfile<'info> {
         has_one = authority,
     )]
     pub user: Account<'info, User>,
-    #[account(mut)]
     pub authority: Signer<'info>,
     // The system program
     pub system_program: Program<'info, System>,

--- a/programs/gpl_core/src/instructions/profile_metadata.rs
+++ b/programs/gpl_core/src/instructions/profile_metadata.rs
@@ -11,6 +11,8 @@ use crate::constants::*;
 #[derive(Accounts)]
 #[instruction(metadata_uri: String)]
 pub struct CreateProfileMetadata<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
     // The account that will be initialized as a ProfileMetadata
     #[account(
         init,
@@ -19,7 +21,7 @@ pub struct CreateProfileMetadata<'info> {
             profile.to_account_info().key.as_ref(),
         ],
         bump,
-        payer = authority,
+        payer = payer,
         space = ProfileMetadata::LEN
     )]
     pub profile_metadata: Account<'info, ProfileMetadata>,
@@ -42,7 +44,6 @@ pub struct CreateProfileMetadata<'info> {
         has_one = authority,
     )]
     pub user: Account<'info, User>,
-    #[account(mut)]
     pub authority: Signer<'info>,
     // The system program
     pub system_program: Program<'info, System>,

--- a/programs/gpl_core/src/instructions/reaction.rs
+++ b/programs/gpl_core/src/instructions/reaction.rs
@@ -13,6 +13,8 @@ use gpl_session::{session_auth_or, Session, SessionError, SessionToken};
 #[derive(Accounts, Session)]
 #[instruction(reaction_type: String)]
 pub struct CreateReaction<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
     // The account that will be initialized as a Reaction
     #[account(
         init,
@@ -23,7 +25,7 @@ pub struct CreateReaction<'info> {
             from_profile.to_account_info().key.as_ref(),
         ],
         bump,
-        payer = authority,
+        payer = payer,
         space = Reaction::LEN
     )]
     pub reaction: Account<'info, Reaction>,
@@ -60,7 +62,6 @@ pub struct CreateReaction<'info> {
     )]
     pub session_token: Option<Account<'info, SessionToken>>,
 
-    #[account(mut)]
     pub authority: Signer<'info>,
 
     // The system program

--- a/programs/gpl_core/src/instructions/user.rs
+++ b/programs/gpl_core/src/instructions/user.rs
@@ -8,6 +8,8 @@ use crate::state::User;
 #[derive(Accounts)]
 #[instruction(random_hash: [u8;32])]
 pub struct CreateUser<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
     // The account that will be initialized as a user
     #[account(
         init,
@@ -16,12 +18,11 @@ pub struct CreateUser<'info> {
             random_hash.as_ref(),
         ],
         bump,
-        payer = authority,
+        payer = payer,
         space = User::LEN
     )]
     pub user: Account<'info, User>,
     // The authority of the user
-    #[account(mut)]
     pub authority: Signer<'info>,
     // The system program
     pub system_program: Program<'info, System>,

--- a/tests/gpl_core/connection.spec.ts
+++ b/tests/gpl_core/connection.spec.ts
@@ -49,7 +49,7 @@ describe("Connection", async () => {
     const randomTestHash = randombytes(32);
     const createTestUser = program.methods
       .createUser(randomTestHash)
-      .accounts({ authority: testUser.publicKey });
+      .accounts({ payer: testUser.publicKey, authority: testUser.publicKey });
     const testUserPubKeys = await createTestUser.pubkeys();
     testUserPDA = testUserPubKeys.user as anchor.web3.PublicKey;
     const testUserTx = await createTestUser.transaction();
@@ -67,7 +67,7 @@ describe("Connection", async () => {
     // Create a testProfile
     const testProfile = program.methods
       .createProfile("Personal")
-      .accounts({ user: testUserPDA, authority: testUser.publicKey });
+      .accounts({ payer: testUser.publicKey, user: testUserPDA, authority: testUser.publicKey });
     const testProfilePubKeys = await testProfile.pubkeys();
     testProfilePDA = testProfilePubKeys.profile as anchor.web3.PublicKey;
     const testProfileTx = await testProfile.transaction();

--- a/tests/gpl_core/post.spec.ts
+++ b/tests/gpl_core/post.spec.ts
@@ -104,7 +104,7 @@ describe("Post", async () => {
       const randomHash = randombytes(32);
       const userTx = program.methods
         .createUser(randomHash)
-        .accounts({ authority: randomUser.publicKey });
+        .accounts({ payer: randomUser.publicKey, authority: randomUser.publicKey });
       const userPubKeys = await userTx.pubkeys();
       randomUserPDA = userPubKeys.user;
       const tx = await userTx.transaction();
@@ -122,7 +122,7 @@ describe("Post", async () => {
       // Create a profile
       const testProfile = program.methods
         .createProfile("Personal")
-        .accounts({ user: randomUserPDA, authority: randomUser.publicKey });
+        .accounts({ payer: randomUser.publicKey, user: randomUserPDA, authority: randomUser.publicKey });
       const testProfilePubKeys = await testProfile.pubkeys();
       randomProfilePDA = testProfilePubKeys.profile as anchor.web3.PublicKey;
       const testProfileTx = await testProfile.transaction();

--- a/tests/gpl_core/profile.spec.ts
+++ b/tests/gpl_core/profile.spec.ts
@@ -2,6 +2,7 @@ import * as anchor from "@project-serum/anchor";
 import randombytes from "randombytes";
 import { expect } from "chai";
 import { GplCore } from "../../target/types/gpl_core";
+import { airdrop } from "../utils";
 
 const program = anchor.workspace.GplCore as anchor.Program<GplCore>;
 
@@ -10,6 +11,7 @@ anchor.setProvider(anchor.AnchorProvider.env());
 describe("Profile", async () => {
   let userPDA: anchor.web3.PublicKey;
   let profilePDA: anchor.web3.PublicKey;
+  let feePayer: anchor.web3.Keypair;
 
   before(async () => {
     // Create a user
@@ -18,6 +20,10 @@ describe("Profile", async () => {
     const pubKeys = await tx.pubkeys();
     userPDA = pubKeys.user as anchor.web3.PublicKey;
     await tx.rpc();
+
+    // Create fee payer keypair
+    feePayer = anchor.web3.Keypair.generate();
+    await airdrop(feePayer.publicKey);
   });
 
   it("should create a profile", async () => {
@@ -47,5 +53,19 @@ describe("Profile", async () => {
         `Account does not exist or has no data ${profilePDA.toString()}`
       );
     }
+  });
+
+  it("should create a profile when a seperate fee payer is specified", async () => {
+    const tx = program.methods
+      .createProfile("Personal")
+      .accounts({ payer: feePayer.publicKey, user: userPDA });
+    const pubKeys = await tx.pubkeys();
+    profilePDA = pubKeys.profile as anchor.web3.PublicKey;
+    await tx.signers([feePayer]).rpc();
+    const profileAccount = await program.account.profile.fetch(profilePDA);
+    expect(profileAccount.user.toString()).is.equal(userPDA.toString());
+    expect(profileAccount.namespace.toString()).is.equal(
+      { personal: {} }.toString()
+    );
   });
 });

--- a/tests/gpl_core/reaction.spec.ts
+++ b/tests/gpl_core/reaction.spec.ts
@@ -2,7 +2,7 @@ import * as anchor from "@project-serum/anchor";
 import randombytes from "randombytes";
 import { expect } from "chai";
 import { GplCore } from "../../target/types/gpl_core";
-import { new_session } from "../utils";
+import { airdrop, new_session } from "../utils";
 
 const program = anchor.workspace.GplCore as anchor.Program<GplCore>;
 
@@ -15,6 +15,7 @@ describe("Reaction", async () => {
   let profilePDA: anchor.web3.PublicKey;
   let postPDA: anchor.web3.PublicKey;
   let reactionPDA: anchor.web3.PublicKey;
+  let feePayer: anchor.web3.Keypair;
 
   before(async () => {
     // Create a user
@@ -41,6 +42,10 @@ describe("Reaction", async () => {
     const postPubKeys = await post.pubkeys();
     postPDA = postPubKeys.post as anchor.web3.PublicKey;
     await post.rpc();
+
+    // Create fee payer keypair
+    feePayer = anchor.web3.Keypair.generate();
+    await airdrop(feePayer.publicKey);
   });
 
   it("should create a reaction", async () => {
@@ -83,6 +88,38 @@ describe("Reaction", async () => {
         `Account does not exist or has no data ${reactionPDA.toString()}`
       );
     }
+  });
+
+  it("should create a reaction when a seperate fee payer is specified", async () => {
+    const reaction = program.methods.createReaction("Haha").accounts({
+      payer: feePayer.publicKey,
+      toPost: postPDA,
+      fromProfile: profilePDA,
+      user: userPDA,
+      sessionToken: null,
+    });
+    const reactionPubKeys = await reaction.pubkeys();
+    reactionPDA = reactionPubKeys.reaction as anchor.web3.PublicKey;
+    await reaction.signers([feePayer]).rpc();
+
+    const reactionAccount = await program.account.reaction.fetch(reactionPDA);
+    expect(reactionAccount.toPost.toBase58()).to.equal(postPDA.toBase58());
+    expect(reactionAccount.fromProfile.toBase58()).to.equal(
+      profilePDA.toBase58()
+    );
+    expect(reactionAccount.reactionType.toString()).to.equal(
+      { haha: {} }.toString()
+    );
+
+    // Clean up for next tests
+    await program.methods.deleteReaction().accounts({
+      toPost: postPDA,
+      fromProfile: profilePDA,
+      user: userPDA,
+      reaction: reactionPDA,
+      sessionToken: null,
+      refundReceiver: provider.wallet.publicKey,
+    }).rpc();
   });
 
   describe("Reaction with session token", async () => {


### PR DESCRIPTION
This PR is to add a `payer` field to all `Create_` structs (`CreatePost`, `CreateUser` etc.). The `payer` field will allow for and account other than the `authority` to pay for the creation of accounts (Posts, Users etc.).

The main reason for this change is to facilitate PDAs to be the `authority` on user accounts.